### PR TITLE
Fix shadowtls utlsEnabled option cannot be saved

### DIFF
--- a/app_singbox/build.gradle.kts
+++ b/app_singbox/build.gradle.kts
@@ -8,8 +8,8 @@ setupAll()
 android {
     defaultConfig {
         applicationId = "moe.matsuri.plugin.singbox"
-        versionCode = 3
-        versionName = "v1.2-beta5"
+        versionCode = 4
+        versionName = "v1.2-beta5-2"
         splits.abi {
             reset()
             include("arm64-v8a", "x86_64")

--- a/js/plugin_singbox/shadowtls.js
+++ b/js/plugin_singbox/shadowtls.js
@@ -21,7 +21,7 @@ class shadowTlsClass {
     this.defaultSharedStorage.shadowTlsServerName = "";
     this.defaultSharedStorage.shadowTlsServerPassword = "";
     this.defaultSharedStorage.shadowTlsVersion = "2";
-    this.defaultSharedStorage.utlsEnabled = false;
+    this.defaultSharedStorage.utlsEnabled = "false";
     this.defaultSharedStorage.utlsFingerprint = "chrome";
 
     for (var k in this.defaultSharedStorage) {


### PR DESCRIPTION
Matsuri设置界面初始化时，`utlsEnabled`会被设置为默认值，原因是`false`为Boolean类型，改为String类型就解决了。
https://github.com/MatsuriDayo/plugins/blob/aeae2a6f628ea66ef950027b3755c02554a3db87/js/plugin_singbox/shadowtls.js#LL27-L34C6